### PR TITLE
Remove Plasma Mobile

### DIFF
--- a/index.md
+++ b/index.md
@@ -49,7 +49,7 @@ Most distributions are discussing with one another to work towards using the sam
 
 ### Which communities are involved with Halium?
 
-[Plasma Mobile](https://www.plasma-mobile.org/), [LuneOS](http://www.webos-ports.org/wiki/Main_Page), [Ubuntu Touch](https://ubuntu-touch.io)... We're only missing you!
+[LuneOS](http://www.webos-ports.org/wiki/Main_Page), [Ubuntu Touch](https://ubuntu-touch.io)... We're only missing you!
 
 ### Why aren't you enhancing the Mer Project instead of creating a new one?
 


### PR DESCRIPTION
Plasma Mobile does not support Halium anymore, so it shouldnt be in the website.