### PR TITLE
Change ubuntu touch to postmarket

### DIFF
--- a/index.md
+++ b/index.md
@@ -49,7 +49,7 @@ Most distributions are discussing with one another to work towards using the sam
 
 ### Which communities are involved with Halium?
 
-[LuneOS](http://www.webos-ports.org/wiki/Main_Page), [Ubuntu Touch](https://ubuntu-touch.io)... We're only missing you!
+[LuneOS](http://www.webos-ports.org/wiki/Main_Page), [PostMarket OS](https://postmarketos.org/)... We're only missing you!
 
 ### Why aren't you enhancing the Mer Project instead of creating a new one?
 


### PR DESCRIPTION
 UBports has been actively using halium for quite a while